### PR TITLE
🧪 [Testing] Add test coverage for WSLogout catch block

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,14 +33,17 @@
     "@vitejs/plugin-vue": "^6.0.0",
     "@vue/cli-plugin-babel": "^5.0.8",
     "@vue/eslint-config-prettier": "^9.0.0",
+    "@vue/test-utils": "^2.4.11",
     "eslint": "^8.11.0",
     "eslint-plugin-vue": "^9.21.1",
+    "jsdom": "^29.1.1",
     "knip": "^5.62.0",
     "prettier": "^3.2.5",
     "rollup-plugin-visualizer": "^6.0.3",
     "vite": "^7.0.6",
     "vite-plugin-html": "^3.2.2",
-    "vite-plugin-pwa": "^1.0.2"
+    "vite-plugin-pwa": "^1.0.2",
+    "vitest": "^4.1.9"
   },
   "eslintConfig": {
     "root": true,

--- a/frontend/src/views/WSLogout.spec.js
+++ b/frontend/src/views/WSLogout.spec.js
@@ -1,0 +1,65 @@
+import { mount } from "@vue/test-utils";
+import { describe, it, expect, vi } from "vitest";
+import { createStore } from "vuex";
+import WSLogout from "./WSLogout.vue";
+
+describe("WSLogout.vue", () => {
+  it("dispatches login/logout on mount and handles success", async () => {
+    const logoutAction = vi.fn().mockResolvedValue();
+
+    const store = createStore({
+      modules: {
+        login: {
+          namespaced: true,
+          actions: {
+            logout: logoutAction,
+          },
+        },
+      },
+    });
+
+    mount(WSLogout, {
+      global: {
+        plugins: [store],
+        stubs: {
+          CardModule: true,
+          RouterLink: true,
+        }
+      },
+    });
+
+    expect(logoutAction).toHaveBeenCalled();
+  });
+
+  it("logs an error if logout fails", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const store = createStore({
+      modules: {
+        login: {
+          namespaced: true,
+          actions: {
+            logout: () => Promise.reject(new Error("Network Error")),
+          },
+        },
+      },
+    });
+
+    mount(WSLogout, {
+      global: {
+        plugins: [store],
+        stubs: {
+          CardModule: true,
+          RouterLink: true,
+        }
+      },
+    });
+
+    // Wait for the microtask queue to process the rejected promise
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(consoleSpy).toHaveBeenCalledWith("Logout failed.");
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -60,4 +60,7 @@ export default defineConfig({
       // '@': path.resolve(__dirname, './src'),
     },
   },
+  test: {
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested catch block in the WSLogout Vue component when `store.dispatch("login/logout")` failed.
📊 **Coverage:** A new test file `WSLogout.spec.js` was introduced to verify that `console.error("Logout failed.")` is called when the login/logout action returns a rejected promise. Additionally, a happy path test was also added to check the successful dispatching.
✨ **Result:** Test coverage improved as the component's edge case is now tested, acting as a safety net against future regressions.

---
*PR created automatically by Jules for task [17537441749498474053](https://jules.google.com/task/17537441749498474053) started by @guidohu*